### PR TITLE
Fix `docEditBase` being ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
   function create(docBase, docEditBase, title) {
     title = title || 'Edit on github'
-    docEditBase = docBase.replace(/\/blob\//, '/edit/')
+    docEditBase = docEditBase || docBase.replace(/\/blob\//, '/edit/')
 
     function editDoc(event, vm) {
       var docName = vm.route.file


### PR DESCRIPTION
Currently if the user specify a `docEditBase`, it will be ignored as we don't use the value. (directly overrided see [line 6](https://github.com/njleonzhang/docsify-edit-on-github/blob/6ece9932ce47bebbcc5a8258cd7bebde6730801e/index.js#L6))
This fix this by looking at the value first and only then defaulting to the default value.